### PR TITLE
Fixed module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,10 +5,10 @@
   "keywords": [],
   "author": "Alessandro Angelino <alessandro.angelino@arm.com>",
   "repository": {
-    "url": "git@github.com:ARMmbed/uvisor-helloworld-private.git",
+    "url": "git@github.com:ARMmbed/uvisor-helloworld.git",
     "type": "git"
   },
-  "homepage": "https://github.com/ARMmbed/uvisor-helloworld-private",
+  "homepage": "https://github.com/ARMmbed/uvisor-helloworld",
   "licenses": [
     {
       "url": "https://spdx.org/licenses/Apache-2.0",


### PR DESCRIPTION
No longer specify private repositories. uVisor is now re-licensed under
Apache 2.0 license.