### PR TITLE
Fix preprocessor defs

### DIFF
--- a/source/box-challenge-hw.h
+++ b/source/box-challenge-hw.h
@@ -18,17 +18,17 @@
 #define __BOX_CHALLENGE_HW_H__
 
 /* target specifc ACLs */
-#if   defined(TARGET_LIKE_FRDM_K64F_GCC)
+#if   defined(TARGET_LIKE_FRDM_K64F)
 
 #define BOX_CHALLENGE_ACL(acl_list_name) \
-    static const UvisorBoxAclItem g_box_acl[] = {       \
+    static const UvisorBoxAclItem acl_list_name[] = {   \
         {RNG,   sizeof(*RNG),   UVISOR_TACLDEF_PERIPH}  \
     }
 
-#elif defined(TARGET_LIKE_STM32F429I_DISCO_GCC)
+#elif defined(TARGET_LIKE_STM32F429I_DISCO)
 
 #define BOX_CHALLENGE_ACL(acl_list_name) \
-    static const UvisorBoxAclItem g_box_acl[] = {       \
+    static const UvisorBoxAclItem acl_list_name[] = {   \
         {RNG,   sizeof(*RNG),   UVISOR_TACLDEF_PERIPH}  \
     }
 

--- a/source/box-challenge-hw.h
+++ b/source/box-challenge-hw.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __BOX_CHALLENGE_HW_H__
-#define __BOX_CHALLENGE_HW_H__
+#ifndef __UVISOR_HELLOWORLD_BOX_CHALLENGE_HW_H__
+#define __UVISOR_HELLOWORLD_BOX_CHALLENGE_HW_H__
 
 /* target specifc ACLs */
 #if   defined(TARGET_LIKE_FRDM_K64F)
@@ -39,4 +39,4 @@
 
 #endif
 
-#endif/*__BOX_CHALLENGE_HW_H__*/
+#endif/*__UVISOR_HELLOWORLD_BOX_CHALLENGE_HW_H__*/

--- a/source/box-challenge.h
+++ b/source/box-challenge.h
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __BOX_CHALLENGE_H__
-#define __BOX_CHALLENGE_H__
+#ifndef __UVISOR_HELLOWORLD_BOX_CHALLENGE_H__
+#define __UVISOR_HELLOWORLD_BOX_CHALLENGE_H__
 
 #define CHALLENGE_SIZE 16
 
 extern bool verify_secret(const uint8_t *secret, int len);
 extern void *g_box_context;
 
-#endif/*__BOX_CHALLENGE_H__*/
+#endif/*__UVISOR_HELLOWORLD_BOX_CHALLENGE_H__*/

--- a/source/btn.h
+++ b/source/btn.h
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __BTN_H__
-#define __BTN_H__
+#ifndef __UVISOR_HELLOWORLD_BTN_H__
+#define __UVISOR_HELLOWORLD_BTN_H__
 
 void btn_init(void);
 
-#endif/*__BTN_H__*/
+#endif/*__UVISOR_HELLOWORLD_BTN_H__*/

--- a/source/main-hw.h
+++ b/source/main-hw.h
@@ -23,14 +23,14 @@
 extern uint8_t g_challenge[CHALLENGE_SIZE];
 
 /* target specifc ACLs */
-#if   defined(TARGET_LIKE_FRDM_K64F_GCC)
+#if   defined(TARGET_LIKE_FRDM_K64F)
 
 #define LED_ON  false
 #define LED_OFF true
 #define MAIN_LED LED_BLUE
 #define MAIN_BTN SW2
 #define MAIN_ACL(acl_list_name) \
-    static const UvisorBoxAclItem g_main_acl[] = {      \
+    static const UvisorBoxAclItem acl_list_name[] = {     \
         {MCG,    sizeof(*MCG),    UVISOR_TACLDEF_PERIPH}, \
         {SIM,    sizeof(*SIM),    UVISOR_TACLDEF_PERIPH}, \
         {PORTB,  sizeof(*PORTB),  UVISOR_TACLDEF_PERIPH}, \
@@ -40,14 +40,14 @@ extern uint8_t g_challenge[CHALLENGE_SIZE];
         {PIT,    sizeof(*PIT),    UVISOR_TACLDEF_PERIPH}, \
     }
 
-#elif defined(TARGET_LIKE_STM32F429I_DISCO_GCC)
+#elif defined(TARGET_LIKE_STM32F429I_DISCO)
 
 #define LED_ON  false
 #define LED_OFF true
 #define MAIN_LED LED1
 #define MAIN_BTN USER_BUTTON
 #define MAIN_ACL(acl_list_name)                           \
-    static const UvisorBoxAclItem g_main_acl[] = {        \
+    static const UvisorBoxAclItem acl_list_name[] = {     \
         {TIM2,   sizeof(*TIM2),   UVISOR_TACLDEF_PERIPH}, \
         {TIM5,   sizeof(*TIM5),   UVISOR_TACLDEF_PERIPH}, \
         {GPIOA,  sizeof(*GPIOA),  UVISOR_TACLDEF_PERIPH}, \

--- a/source/main-hw.h
+++ b/source/main-hw.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __MAIN_HW_H__
-#define __MAIN_HW_H__
+#ifndef __UVISOR_HELLOWORLD_MAIN_HW_H__
+#define __UVISOR_HELLOWORLD_MAIN_HW_H__
 
 /* the vector containing the challenge is shared with the push-button ISR, so
  * that it can attempt to access it from an IRQ context */
@@ -69,4 +69,4 @@ extern uint8_t g_challenge[CHALLENGE_SIZE];
 
 #endif
 
-#endif/*__MAIN_HW_H__*/
+#endif/*__UVISOR_HELLOWORLD_MAIN_HW_H__*/


### PR DESCRIPTION
Fixing minor bug on pre-processor definitions.

`#define`s for conditional header file inclusion have been added for consistency with the rest of mbed