### PR TITLE
Removed config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-  "uvisor": {
-    "present" : 1
-  }
-}


### PR DESCRIPTION
The `UVISOR_PRESENT` symbol is now defined on a per-target basis (see https://github.com/ARMmbed/target-frdm-k64f-gcc/pull/20, https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/23).

Fixes builds of uvisor-helloworld with unsupported targets.

@meriac 