### PR TITLE
Fix comment and duplicated ACLs

### DIFF
--- a/source/box-challenge.cpp
+++ b/source/box-challenge.cpp
@@ -27,7 +27,7 @@ typedef struct {
 /* create ACLs for secret data section */
 BOX_CHALLENGE_ACL(g_box_acl);
 
-/* configure secure box compartnent and reserve box context */
+/* configure secure box compartment and reserve box context */
 UVISOR_BOX_CONFIG(box_challenge, g_box_acl, UVISOR_BOX_STACK_SIZE, BoxContext);
 
 void *g_box_context;

--- a/source/main-hw.h
+++ b/source/main-hw.h
@@ -62,7 +62,6 @@ extern uint8_t g_challenge[CHALLENGE_SIZE];
         {SYSCFG, sizeof(*SYSCFG), UVISOR_TACLDEF_PERIPH}, \
         {FLASH,  sizeof(*FLASH),  UVISOR_TACLDEF_PERIPH}, \
         {PWR,    sizeof(*PWR),    UVISOR_TACLDEF_PERIPH}, \
-        {RCC,    sizeof(*RCC),    UVISOR_TACLDEF_PERIPH}, \
         {USART1, sizeof(*USART1), UVISOR_TACLDEF_PERIPH}, \
         {(void *) 0x42470000, 0x1000, UVISOR_TACLDEF_PERIPH}, \
     }


### PR DESCRIPTION
1.Fix the misspelled the word in comments.
2.Remove the duplicated RCC in the ACLs of main box.