### PR TITLE
Fix initialization bug in secure box

### DIFF
--- a/source/box-challenge.cpp
+++ b/source/box-challenge.cpp
@@ -77,10 +77,12 @@ UVISOR_EXTERN bool __verify_secret(const uint8_t *secret, int len)
 
     /* FIXME verify that secret pointer points outside of box stack context */
 
-    /* generate new secret on the first run
-     * FIXME enable clocks for HW-RNG */
-    if(!uvisor_ctx->initialized)
+    /* Generate new secret on the first run. */
+    /* FIXME enable clocks for HW-RNG */
+    if (!uvisor_ctx->initialized) {
         randomize_new_secret();
+        uvisor_ctx->initialized = true;
+    }
 
     return secure_compare(secret, uvisor_ctx->secret, len);
 }


### PR DESCRIPTION
The secret was repeatedly initialized due to an unchanged flag. The bug
was originally not observed since the secret is currently not
randomized, so it stayed always the same across subsequent reading
attempts.

Fixes: 79011cb ("Example of (failing) security breach attempt")

@meriac @Patater 