### PR TITLE
Add prototype debug box

### DIFF
--- a/source/box-challenge.cpp
+++ b/source/box-challenge.cpp
@@ -28,6 +28,7 @@ typedef struct {
 BOX_CHALLENGE_ACL(g_box_acl);
 
 /* configure secure box compartment and reserve box context */
+UVISOR_BOX_NAMESPACE(NULL);
 UVISOR_BOX_CONFIG(box_challenge, g_box_acl, UVISOR_BOX_STACK_SIZE, BoxContext);
 
 void *g_box_context;

--- a/source/box-debug.cpp
+++ b/source/box-debug.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed-drivers/mbed.h"
+#include "uvisor-lib/uvisor-lib.h"
+#include "box-debug.h"
+#include "main-hw.h"
+
+/* Delay between single blinks of a pattern. Patterns are repeated multiple
+ * times, with a delay of twice the number below between them. */
+#define BOX_DEBUG_LED_DELAY 0x400000
+
+/* Configure the debug box. */
+UVISOR_BOX_NAMESPACE(NULL);
+UVISOR_BOX_CONFIG(box_debug, UVISOR_BOX_STACK_SIZE);
+
+/* This handler returns the driver version used for the debug box.
+ * uVisor will check this version against the available ones. */
+static uint32_t get_version(void)
+{
+    return 0;
+}
+
+/* This handler emits a blinking LED pattern for three times. A blinking LED
+ * pattern is made of as many blinks as the value of the error reason, provided
+ * by uVisor. */
+static void halt_error(int reason)
+{
+    int i, k;
+    int volatile j;
+    static DigitalOut halt_led(LED_RED);
+
+    halt_led = LED_OFF;
+    for (k = 0; k < 3; k++) {
+        for (i = 0; i < reason; i++) {
+            for (j = 0; j < BOX_DEBUG_LED_DELAY; j++);
+            halt_led = LED_ON;
+            for (j = 0; j < BOX_DEBUG_LED_DELAY; j++);
+            halt_led = LED_OFF;
+        }
+        for (j = 0; j < (2 * BOX_DEBUG_LED_DELAY); j++);
+    }
+
+    /* uVisor will reboot upon return. */
+    return;
+}
+
+UVISOR_EXTERN void __box_debug_init(void)
+{
+    /* Debug box driver -- Version 0 */
+    static const TUvisorDebugDriver driver = {
+        get_version,
+        halt_error
+    };
+
+    /* Register the debug box with uVisor. */
+    uvisor_debug_init(&driver);
+}
+
+void box_debug::init(void)
+{
+    /* The debug box is initialized from the context of box_debug. */
+    secure_gateway(box_debug, __box_debug_init);
+}

--- a/source/box-debug.h
+++ b/source/box-debug.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_HELLOWORLD_BOX_DEBUG_H__
+#define __UVISOR_HELLOWORLD_BOX_DEBUG_H__
+
+namespace box_debug {
+    extern void init(void);
+}
+
+#endif /* __UVISOR_HELLOWORLD_BOX_DEBUG_H__ */

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -20,6 +20,7 @@
 #include "uvisor-lib/uvisor-lib.h"
 #include "main-hw.h"
 #include "box-challenge.h"
+#include "box-debug.h"
 #include "btn.h"
 
 using mbed::util::FunctionPointer0;
@@ -66,6 +67,9 @@ void app_start(int, char *[])
     pc.baud(115200);
 
     pc.printf("***** uvisor-helloworld example *****\n\r");
+
+    /* Initialize the debug box. */
+    box_debug::init();
 
     /* reset challenge */
     memset(&g_challenge, 0, sizeof(g_challenge));


### PR DESCRIPTION
**Please do NOT merge while https://github.com/ARMmbed/uvisor/pull/178 is under review.**

This PR introduces an example debug box that shows how to use the newly introduced uVisor support for de-privileged debug handlers.

The example shows how the debug box:
* Registers its driver handlers for `get_version()` (currently not implemented in uVisor) and `halt_error(int reason)`.
* Blinks an LED patterns 2 times using that pattern.

The application is rebooted by uVisor when `halt_error` returns.

@meriac @Patater 