### PR TITLE
Swap LED_{ON, OFF} for the STM32 board

### DIFF
--- a/source/main-hw.h
+++ b/source/main-hw.h
@@ -49,8 +49,8 @@ extern uint8_t g_challenge[CHALLENGE_SIZE];
 
 #elif defined(TARGET_LIKE_STM32F429I_DISCO)
 
-#define LED_ON  false
-#define LED_OFF true
+#define LED_ON  true
+#define LED_OFF false
 
 #define MAIN_LED LED1
 #define HALT_LED LED2


### PR DESCRIPTION
The on/off logic values were inverted.

Fixes: ad210a7 ("Header files with ACLs renamed to name-hw.h")

@Patater @meriac 